### PR TITLE
Call token_get_all with TOKEN_PARSE flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
   - travis_retry composer install --no-interaction --prefer-source --dev
 
 script:
-  - phpunit --coverage-text --coverage-clover=./build/coverage.clover
+  - ./vendor/bin/phpunit --coverage-text --coverage-clover=./build/coverage.clover
 
 after_script:
   - if [ "$COVERAGE" == "on" ]; then wget https://scrutinizer-ci.com/ocular.phar  -O build/ocular.phar; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,19 @@ language: php
 
 php:
   - 7.0
+  - 7.1
+
+env:
+  - COVERAGE=on
+  - COVERAGE=off
 
 matrix:
   fast_finish: true
+  exclude:
+    - php: 7.0
+      env: COVERAGE=on
+    - php: 7.1
+      env: COVERAGE=off
 
 before_script:
   - travis_retry composer self-update
@@ -14,5 +24,5 @@ script:
   - phpunit --coverage-text --coverage-clover=./build/coverage.clover
 
 after_script:
-  - if [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then wget https://scrutinizer-ci.com/ocular.phar  -O build/ocular.phar; fi
-  - if [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then php ./build/ocular.phar code-coverage:upload --format=php-clover ./build/coverage.clover; fi
+  - if [ "$COVERAGE" == "on" ]; then wget https://scrutinizer-ci.com/ocular.phar  -O build/ocular.phar; fi
+  - if [ "$COVERAGE" == "on" ]; then php ./build/ocular.phar code-coverage:upload --format=php-clover ./build/coverage.clover; fi

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -19,7 +19,13 @@
      * @throws Exception
      */
     public static function getTokensFromString($code) {
-      $tokens = token_get_all($code, TOKEN_PARSE);
+      try {
+        $tokens = token_get_all($code, TOKEN_PARSE);
+      } catch (\ParseError $e) {
+        // with TOKEN_PARSE flag, the function throws on invalid code
+        // let's just ignore the error and tokenize the code without the flag
+        $tokens = token_get_all($code);
+      }
 
       foreach ($tokens as $index => $tokenData) {
 

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -19,7 +19,7 @@
      * @throws Exception
      */
     public static function getTokensFromString($code) {
-      $tokens = token_get_all($code);
+      $tokens = token_get_all($code, TOKEN_PARSE);
 
       foreach ($tokens as $index => $tokenData) {
 

--- a/tests/Tokenizer/CollectionTest.php
+++ b/tests/Tokenizer/CollectionTest.php
@@ -192,4 +192,13 @@
       static::assertEquals($last, $newCollection->getLast());
 
     }
+
+
+    public function testTokenParse() {
+      $collection = Collection::createFromString("<?php class Foo { function forEach() {} }");
+
+      $forEach = $collection[9];
+      static::assertEquals('forEach', $forEach->getValue());
+      static::assertEquals(T_STRING, $forEach->getType());
+    }
   }


### PR DESCRIPTION
The flag has been added in PHP 7.0 and "recognises the ability to use reserved words in specific contexts" (http://php.net/token_get_all), e.g. `forEach` used as a method name is a `T_STRING` token instead of `T_FOREACH`.

This is *technically* a BC break as it alters the behavior of the tokenizer, but it only affects a limited set of edge cases and actually gives more correct results for them, so it might be more of a fix than a breaking change.

Anyway, I'd like to get your opinion on this first; if you're ok with the change, I'll gladly add a test for it. (And maybe a note in the docs?)