### PR TITLE
Fix null value

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -32,7 +32,7 @@ class Helper
 
                 /** @var Token $previousToken */
                 $previousToken = $tokens[$previousIndex];
-                $line = $previousToken->getLine() + substr_count($previousToken->getValue(), "\n");
+                $line = $previousToken->getLine() + substr_count((string)$previousToken->getValue(), "\n");
                 $tokenData = [
                     Token::INVALID_TYPE,
                     $tokenData,

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -32,7 +32,7 @@ class Helper
 
                 /** @var Token $previousToken */
                 $previousToken = $tokens[$previousIndex];
-                $line = $previousToken->getLine() + substr_count((string)$previousToken->getValue(), "\n");
+                $line = $previousToken->getLine() + substr_count((string) $previousToken->getValue(), "\n");
                 $tokenData = [
                     Token::INVALID_TYPE,
                     $tokenData,


### PR DESCRIPTION
`getValue` can return null|string and we pass this value to `substr_count` so it should be definitely string